### PR TITLE
feat: 프로젝트 단건 조회/수정/삭제 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ node_modules/
 .env
 .husky
 prisma/migrations/
+dist/
+build/
+out/
+coverage/
+*.log
+logs/
+src/generated/prisma/

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -129,6 +129,10 @@ model CompanyImage {
 model Image {
   id          Int      @id @default(autoincrement())
   url         String
+  projectId   Int?
+  companyId   Int?
+  showroomId  Int?
+  furnitureId Int?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   isDeleted   Boolean  @default(false)

--- a/src/enums/project-enum.ts
+++ b/src/enums/project-enum.ts
@@ -1,0 +1,8 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+export const ProjectTypeEnum = {
+  RESIDENCE: 'RESIDENCE',
+  MERCANTILE: 'MERCANTILE',
+  ARCHITECTURE: 'ARCHITECTURE',
+} as const;
+
+export type ProjectType = (typeof ProjectTypeEnum)[keyof typeof ProjectTypeEnum];

--- a/src/routers/projects-router.ts
+++ b/src/routers/projects-router.ts
@@ -1,9 +1,18 @@
 import express from 'express';
-import { createProject, getProjects } from '../controllers/project-controller';
+import {
+  createProject,
+  getProjects,
+  getProjectById,
+  updateProject,
+  deleteProject,
+} from '../controllers/project-controller';
 
 const projects = express.Router();
 
-projects.post('/projects', createProject);
 projects.get('/projects', getProjects);
+projects.get('/projects/:id', getProjectById);
+projects.post('/projects', createProject);
+projects.patch('/projects/:id', updateProject);
+projects.delete('/projects/:id', deleteProject);
 
 export default projects;

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { ProjectRepository } from '../repositories/project-repository';
 import { CreateProjectDto, GetProjectsQuery } from '../types/project-type';
 
@@ -11,5 +12,17 @@ export class ProjectService {
   }
   async getProjects(query: GetProjectsQuery) {
     return await this.projectRepository.findProjects(query);
+  }
+
+  async getProjectById(id: number) {
+    return await this.projectRepository.findProjectById(id);
+  }
+
+  async updateProject(id: number, data: Prisma.ProjectUpdateInput) {
+    return await this.projectRepository.updateProject(id, data);
+  }
+
+  async deleteProject(id: number) {
+    return await this.projectRepository.softDeleteProject(id);
   }
 }

--- a/src/types/project-type.ts
+++ b/src/types/project-type.ts
@@ -1,4 +1,5 @@
 import { ProjectType } from '@prisma/client';
+
 export interface CreateProjectDto {
   title: string;
   areaSize: number;
@@ -11,12 +12,39 @@ export interface CreateProjectDto {
   projectImages?: string[];
 }
 
+export type UpdateProjectDto = Partial<CreateProjectDto>;
+
 export type GetProjectsQuery = {
   page: number; // 1+
   pageSize: number; // 1~100
   q?: string; // 제목/설명 검색
   type: ProjectType;
   tagIds?: number[]; // AND 필터 (모든 tag 포함)
-  includeImages?: boolean; // 프로젝트-이미지 조인 포함
-  includeTags?: boolean; // 프로젝트-태그 조인 포함
+};
+
+// 목록조회 결과 항목
+export type ProjectList = {
+  id: number;
+  title: string;
+  areaSize: number;
+  type: ProjectType;
+  createdAt: string; // ISO 문자열로 노출
+  imageUrl?: string;
+};
+
+// 상세조회 결과 항목
+export type ProjectDetail = ProjectList & {
+  description?: string;
+  durationWeeks?: number;
+  reviews?: string;
+  images?: Array<{ id: number; url: string }>;
+  tags?: Array<{ id: number; name: string }>;
+};
+
+// 페이징 결과 공용 타입
+export type Paged<T> = {
+  page: number;
+  pageSize: number;
+  total: number;
+  rows: T[];
 };

--- a/src/utils/query-parser.ts
+++ b/src/utils/query-parser.ts
@@ -1,0 +1,34 @@
+import { ProjectType } from '@prisma/client';
+
+export function toNumber(v: unknown, fallback = 1, min?: number, max?: number): number {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return fallback;
+  const boundedMin = min !== undefined ? Math.max(min, n) : n;
+  const bounded = max !== undefined ? Math.min(max, boundedMin) : boundedMin;
+  return bounded;
+}
+
+export function toString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim() ? v : undefined;
+}
+
+export function toNumberArray(v: unknown): number[] | undefined {
+  if (typeof v !== 'string' || !v.trim()) return undefined;
+  const arr = v
+    .split(',')
+    .map((s) => Number(s.trim()))
+    .filter(Number.isFinite);
+  return arr.length ? arr : undefined;
+}
+
+export function toBool(v: unknown): boolean | undefined {
+  if (v === '1') return true;
+  if (v === '0') return false;
+  return undefined;
+}
+
+export function parseProjectType(v: unknown): ProjectType | undefined {
+  if (typeof v !== 'string') return undefined;
+  const allowed: readonly ProjectType[] = ['RESIDENCE', 'MERCANTILE', 'ARCHITECTURE'];
+  return allowed.includes(v as ProjectType) ? (v as ProjectType) : undefined;
+}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 계약 목록 페이지네이션 구현 -->

## 🎯 목적(Purpose)
- 기존에는 프로젝트 생성/목록 API만 존재하여 단건 조회, 수정, 삭제 시나리오가 불완전했습니다.
- 이번 PR에서는 프로젝트 단건 조회 + 부분 수정(PATCH) + 소프트 삭제(DELETE) 기능을 추가하여 CRUD를 완성하고, 실서비스/운영에서 필요한 관리 기능을 지원합니다.

## 📌 제안/변경 내용(Details)
- GET /projects/:id : 프로젝트 단건 조회 (삭제되지 않은 건만 반환, 없으면 404)
- PATCH /projects/:id : 프로젝트 부분 수정 (유효 id 검증, 삭제된 건 수정 불가)
- DELETE /projects/:id : 소프트 삭제(isdeleted=true 마킹), 재조회 시 404
- ProjectRepository 메서드 추가/보완
- 라우터 매핑 수정 (updateProject, deleteProject 핸들러 연결)

## 💡 기대 효과(Benefits)
- CRUD 완성: 프론트엔드/운영 페이지에서 프로젝트 관리 기능 활용 가능
- 데이터 안정성 확보: 소프트 삭제로 데이터 보존 및 복구 여지 확보
- API 응답 일관성: 공통 successResponse 포맷 유지
- 유지보수성 향상: 서비스/레포지토리 계층 분리로 역할 명확

## 🧪 테스트 방법(How to test)
1. 생성
POST /projects 요청으로 새 프로젝트 등록

2. 목록
GET /projects 호출 → 등록한 프로젝트 확인

3. 단건
GET /projects/:id 호출 → 해당 프로젝트 상세 응답

4. 수정
PATCH /projects/:id → title/description 변경 요청
응답 및 DB 데이터 확인

5. 삭제
DELETE /projects/:id → { deleted:true } 응답 확인
이후 GET /projects/:id → 404 응답 확인
GET /projects 목록에서 빠져있는지 확인

## 🔗 관련 이슈(Links)
- Closes #39 
- Relates to #

## 🗂 스코프(Scope)
- 백엔드 프로젝트 모듈 (controllers, services, repositories, routers)

## 🧩 API 변경(있다면)
- 추가
   - GET /projects/:id
   - PATCH /projects/:id
   - DELETE /projects/:id
- 기존 GET /projects (페이지네이션 목록)과 병행 사용

## 🗃 DB/마이그레이션(있다면)
- DB 스키마 변경 없음 (이미 isdeleted 필드 존재)

## 🎨 UI 변경(있다면)
- 없음

## 📈 성능(Performance)

## 🧯 리스크 & 롤백(Risks & Rollback)

## ✅ 체크리스트(Checklist)
- [x] 관련 이슈 지정
- [x] 구현 범위 명확히 정의
- [x] 로컬에서 재현/검증 완료
- [x] 테스트 코드 추가/수정(가능한 범위)
- [x] 코드 컨벤션/네이밍 규칙 준수
- [x] 데드코드/디버그 로그 제거

## 👀 리뷰어 가이드(Review Points)
- 라우터에 updateProject, deleteProject가 올바르게 매핑되었는지
- 컨트롤러에서 id 파싱/검증 로직이 충분한지
- 레포지토리에서 isdeleted=false 조건이 누락되지 않았는지
