### PR TITLE
feat: Showroom API 구현

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import keywordRouter from './routers/keyword-router';
 import authRouter from './routers/auth-router';
 import consultingRouter from './routers/consultings-router';
 import noticeRouter from './routers/notice-router';
+import showroomRouter from './routers/showroom.router';
 
 const app = express();
 
@@ -31,6 +32,7 @@ app.use(keywordRouter);
 app.use(authRouter);
 app.use(consultingRouter);
 app.use(noticeRouter);
+app.use(showroomRouter);
 
 // POST MIDDLEWARE
 app.use(notFoundHandler); // 생성되지 않은 엔드포인트로 접근 시 404 처리

--- a/src/controllers/showroom.controller.ts
+++ b/src/controllers/showroom.controller.ts
@@ -1,0 +1,60 @@
+import { Request, Response, NextFunction } from 'express';
+import { ShowroomService } from '../services/showroom.service';
+import {
+  listQuerySchema,
+  createShowroomSchema,
+  updateShowroomSchema,
+} from '../types/showroom.schema';
+
+export class ShowroomController {
+  static async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      const q = listQuerySchema.parse(req.query);
+      const data = await ShowroomService.list(q);
+      res.json({ data });
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  static async getById(req: Request, res: Response, next: NextFunction) {
+    try {
+      const id = Number(req.params.id);
+      const data = await ShowroomService.getById(id);
+      res.json({ data });
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  static async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const body = createShowroomSchema.parse(req.body);
+      const data = await ShowroomService.create(body);
+      res.status(201).json({ data });
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  static async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const id = Number(req.params.id);
+      const body = updateShowroomSchema.parse(req.body);
+      const data = await ShowroomService.update(id, body);
+      res.json({ data });
+    } catch (e) {
+      next(e);
+    }
+  }
+
+  static async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      const id = Number(req.params.id);
+      const data = await ShowroomService.remove(id);
+      res.json({ data });
+    } catch (e) {
+      next(e);
+    }
+  }
+}

--- a/src/repositories/showroom.repository.ts
+++ b/src/repositories/showroom.repository.ts
@@ -1,0 +1,57 @@
+import type { Prisma } from '@prisma/client';
+import prisma from '../config/db';
+
+export class ShowroomRepository {
+  static async findById(id: number) {
+    return prisma.showroom.findFirst({
+      where: { id, isDeleted: false },
+      include: {
+        showroomImages: { include: { image: true }, orderBy: { imageId: 'asc' } },
+      },
+    });
+  }
+
+  static async findUniqueByName(name: string) {
+    return prisma.showroom.findUnique({ where: { name } });
+  }
+
+  static async create(data: Prisma.ShowroomCreateInput) {
+    return prisma.showroom.create({ data });
+  }
+
+  static async update(id: number, data: Prisma.ShowroomUpdateInput) {
+    return prisma.showroom.update({ where: { id }, data });
+  }
+
+  static async softDelete(id: number) {
+    return prisma.showroom.update({ where: { id }, data: { isDeleted: true } });
+  }
+
+  static async list(params: {
+    where: Prisma.ShowroomWhereInput;
+    skip: number;
+    take: number;
+    orderBy: Prisma.ShowroomOrderByWithRelationInput;
+  }) {
+    const [items, total] = await Promise.all([
+      prisma.showroom.findMany({
+        where: params.where,
+        skip: params.skip,
+        take: params.take,
+        orderBy: params.orderBy,
+        select: {
+          id: true,
+          name: true,
+          address: true,
+          imageUrl: true,
+          openMinutes: true,
+          closeMinutes: true,
+          weeklyOpenDays: true,
+          weeklyCloseDays: true,
+        },
+      }),
+      prisma.showroom.count({ where: params.where }),
+    ]);
+    return { items, total };
+  }
+}

--- a/src/routers/showroom.router.ts
+++ b/src/routers/showroom.router.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { ShowroomController } from '../controllers/showroom.controller';
+
+const router = Router();
+
+router.post('/showrooms', ShowroomController.create);
+router.get('/showrooms', ShowroomController.list);
+router.get('/showrooms/:id', ShowroomController.getById);
+router.patch('/showrooms/:id', ShowroomController.update);
+router.delete('/showrooms/:id', ShowroomController.remove);
+
+export default router;

--- a/src/services/showroom.service.ts
+++ b/src/services/showroom.service.ts
@@ -1,0 +1,197 @@
+import type { Prisma } from '@prisma/client';
+import { ShowroomRepository } from '../repositories/showroom.repository';
+import { BadRequestError, NotFoundError } from '../types/error-type';
+import { normalizePageParams } from '../utils/pagination';
+import type {
+  CreateShowroomInput,
+  UpdateShowroomInput,
+  ListShowroomQuery,
+} from '../types/showroom.schema';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+
+const toHHMM = (mins: number | null | undefined): string | null => {
+  if (mins == null) return null;
+  const h = String(Math.floor(mins / 60)).padStart(2, '0');
+  const m = String(mins % 60).padStart(2, '0');
+  return `${h}:${m}`;
+};
+
+const parseCsv = (csv?: string | null): Set<string> =>
+  new Set(
+    (csv ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  );
+
+const isOpenNow = (
+  it: {
+    weeklyOpenDays?: string | null;
+    weeklyCloseDays?: string | null;
+    openMinutes?: number | null;
+    closeMinutes?: number | null;
+  },
+  dayIndex = new Date().getDay()
+): boolean => {
+  const day = WEEKDAYS[dayIndex];
+  const openDays = parseCsv(it.weeklyOpenDays);
+  const closeDays = parseCsv(it.weeklyCloseDays);
+  if (!openDays.has(day) || closeDays.has(day)) return false;
+  if (it.openMinutes == null || it.closeMinutes == null) return false;
+
+  const now = new Date();
+  const nowM = now.getHours() * 60 + now.getMinutes();
+  const o = it.openMinutes!;
+  const c = it.closeMinutes!;
+  // 일반/야간 영업 모두 처리
+  return c > o ? nowM >= o && nowM < c : nowM >= o || nowM < c;
+};
+
+// 레포 list select와 맞춘 레코드 타입
+type ShowroomListRecord = {
+  id: number;
+  name: string;
+  address: string;
+  imageUrl: string | null;
+  openMinutes: number | null;
+  closeMinutes: number | null;
+  weeklyOpenDays: string | null;
+  weeklyCloseDays: string | null;
+};
+
+export class ShowroomService {
+  static async create(input: CreateShowroomInput) {
+    const dup = await ShowroomRepository.findUniqueByName(input.name);
+    if (dup) throw new BadRequestError('Showroom name already exists');
+
+    const created = await ShowroomRepository.create({ ...input });
+    const detail = await ShowroomRepository.findById(created.id);
+    if (!detail) throw new NotFoundError('Showroom not found');
+    return shapeDetail(detail);
+  }
+
+  static async update(id: number, input: UpdateShowroomInput) {
+    const existing = await ShowroomRepository.findById(id);
+    if (!existing) throw new NotFoundError('Showroom not found');
+
+    await ShowroomRepository.update(id, {
+      name: input.name ?? existing.name,
+      address: input.address ?? existing.address,
+      phoneNumber: input.phoneNumber ?? existing.phoneNumber,
+      description: input.description ?? existing.description,
+      introText: input.introText ?? existing.introText,
+      mapUrl: input.mapUrl ?? existing.mapUrl,
+      imageUrl: input.imageUrl ?? existing.imageUrl,
+      openMinutes: input.openMinutes ?? existing.openMinutes,
+      closeMinutes: input.closeMinutes ?? existing.closeMinutes,
+      weeklyOpenDays: input.weeklyOpenDays ?? existing.weeklyOpenDays,
+      weeklyCloseDays: input.weeklyCloseDays ?? existing.weeklyCloseDays,
+    });
+
+    const detail = await ShowroomRepository.findById(id);
+    if (!detail) throw new NotFoundError('Showroom not found');
+    return shapeDetail(detail);
+  }
+
+  static async remove(id: number) {
+    const existing = await ShowroomRepository.findById(id);
+    if (!existing) throw new NotFoundError('Showroom not found');
+    await ShowroomRepository.softDelete(id);
+    return { ok: true };
+  }
+
+  static async getById(id: number) {
+    const detail = await ShowroomRepository.findById(id);
+    if (!detail) throw new NotFoundError('Showroom not found');
+    return shapeDetail(detail);
+  }
+
+  static async list(query: ListShowroomQuery) {
+    const { skip, take, page, pageSize } = normalizePageParams({
+      page: query.page,
+      pageSize: query.pageSize,
+      maxPageSize: 100,
+    });
+
+    const where: Prisma.ShowroomWhereInput = { isDeleted: false };
+    if (query.q) {
+      where.OR = [
+        { name: { contains: query.q, mode: 'insensitive' } },
+        { address: { contains: query.q, mode: 'insensitive' } },
+        { description: { contains: query.q, mode: 'insensitive' } },
+      ];
+    }
+
+    let orderBy: Prisma.ShowroomOrderByWithRelationInput = { createdAt: 'desc' };
+    if (query.sort === 'name_asc') orderBy = { name: 'asc' };
+    if (query.sort === 'name_desc') orderBy = { name: 'desc' };
+    if (query.sort === 'recent') orderBy = { createdAt: 'desc' };
+
+    const { items, total } = await ShowroomRepository.list({ where, skip, take, orderBy });
+
+    const dayIdx = new Date().getDay();
+    const filtered = (items as ShowroomListRecord[]).filter((it) =>
+      query.openNow ? isOpenNow(it, dayIdx) : true
+    );
+
+    const shaped = filtered.map((it) => ({
+      id: it.id,
+      name: it.name,
+      address: it.address,
+      coverImageUrl: it.imageUrl ?? null,
+      todayHoursText:
+        it.openMinutes == null || it.closeMinutes == null
+          ? null
+          : `${toHHMM(it.openMinutes)} - ${toHHMM(it.closeMinutes)}`,
+    }));
+
+    return {
+      page,
+      pageSize,
+      total: query.openNow ? shaped.length : total,
+      items: shaped,
+    };
+  }
+}
+
+const shapeDetail = (
+  show: NonNullable<Awaited<ReturnType<typeof ShowroomRepository.findById>>>
+) => ({
+  id: show.id,
+  name: show.name,
+  introText: show.introText,
+  description: show.description,
+  address: show.address,
+  phoneNumber: show.phoneNumber,
+  mapUrl: show.mapUrl,
+  coverImageUrl: show.imageUrl ?? null,
+  hours: {
+    open: toHHMM(show.openMinutes),
+    close: toHHMM(show.closeMinutes),
+    weeklyOpenDays: show.weeklyOpenDays, // "Mon,Tue,Wed..."
+    weeklyCloseDays: show.weeklyCloseDays,
+  },
+  spaces: show.showroomImages.map((si) => ({
+    imageUrl: si.image.url,
+    title: null,
+    description: null,
+  })),
+  services: [
+    { code: 'APT', name: '아파트 전문', description: '오랜 경험의 아파트 전문성', iconUrl: null },
+    {
+      code: 'HOUSE',
+      name: '전원주택·노후주택',
+      description: '공간을 새롭게 재구성',
+      iconUrl: null,
+    },
+    { code: 'RETAIL', name: '상업공간', description: '공간별 전략과 경험 설계', iconUrl: null },
+    {
+      code: 'BRANDING',
+      name: '브랜딩·스타일링',
+      description: '아이덴티티가 녹아든 디테일',
+      iconUrl: null,
+    },
+  ],
+});

--- a/src/types/showroom.schema.ts
+++ b/src/types/showroom.schema.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const listQuerySchema = z.object({
+  page: z.coerce.number().optional(),
+  pageSize: z.coerce.number().optional(),
+  q: z.string().optional(),
+  sort: z.enum(['recent', 'name_asc', 'name_desc']).optional(),
+  openNow: z.coerce.boolean().optional(),
+});
+
+export const createShowroomSchema = z.object({
+  name: z.string().min(1).max(255),
+  address: z.string().min(1).max(255),
+  phoneNumber: z.string().max(20).optional().nullable(),
+  description: z.string().optional().nullable(),
+  introText: z.string().optional().nullable(),
+  mapUrl: z.string().url().optional().nullable(),
+  imageUrl: z.string().url().optional().nullable(),
+  openMinutes: z.number().int().min(0).max(1440).optional().nullable(),
+  closeMinutes: z.number().int().min(0).max(1440).optional().nullable(),
+  weeklyOpenDays: z.string().optional().nullable(), // "Mon,Tue,Wed"
+  weeklyCloseDays: z.string().optional().nullable(),
+});
+
+export const updateShowroomSchema = createShowroomSchema.partial();
+
+// 타입 alias (서비스/레포에서 사용)
+export type ListShowroomQuery = z.infer<typeof listQuerySchema>;
+export type CreateShowroomInput = z.infer<typeof createShowroomSchema>;
+export type UpdateShowroomInput = z.infer<typeof updateShowroomSchema>;

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,7 @@
+export type PageParams = { page?: number; pageSize?: number; maxPageSize?: number };
+
+export function normalizePageParams({ page = 1, pageSize = 20, maxPageSize = 100 }: PageParams) {
+  const p = Number.isFinite(page) && page! > 0 ? page! : 1;
+  const s = Math.min(Math.max(1, pageSize!), maxPageSize!);
+  return { skip: (p - 1) * s, take: s, page: p, pageSize: s };
+}


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 계약 목록 페이지네이션 구현 -->

## 🎯 목적
- 홈페이지에서 직영 쇼룸 정보를 관리(등록/조회/수정/삭제)하고, 사용자에게 쇼룸 상세(사진, 소개, 지도, 운영시간 등)를 제공하기 위해 API를 구현했습니다.

## 📌 변경 사항
- showroom.router.ts : 라우터 정의 (절대 경로 /showrooms 기반)
   -POST /showrooms : 쇼룸 생성
   - GET /showrooms : 쇼룸 목록 조회 (검색/정렬/운영중 필터 지원)
   - GET /showrooms/:id : 쇼룸 상세 조회
   - PATCH /showrooms/:id : 쇼룸 수정
   - DELETE /showrooms/:id : 쇼룸 소프트 삭제
- showroom.controller.ts : 요청 검증 + 서비스 호출 + 응답 반환
- showroom.service.ts : 비즈니스 로직 (영업시간 포맷팅, openNow 계산, DTO 변환)
- showroom.repository.ts : Prisma ORM을 통한 DB 접근 메서드 구현
- showroom.schema.ts : zod 스키마 정의 및 타입 추출
- app.ts : 쇼룸 라우터 등록 (app.use(showroomRouter);)

## 💡 기대 효과
- 운영자: 직영 쇼룸 정보를 손쉽게 등록/수정/삭제 가능
- 사용자: 홈페이지에서 각 쇼룸의 위치, 운영시간, 공간 사진, 서비스 안내를 직관적으로 확인 가능

## 🧪 테스트 방법
- 로컬 서버 실행 (npm run dev)
- Postman으로 API 호출 테스트
   - POST /showrooms : 쇼룸 생성 요청 → 201 Created 확인
   - GET /showrooms : 생성된 쇼룸이 목록에 표시되는지 확인
   - GET /showrooms/:id : 상세 조회 정상 동작 확인
   - PATCH /showrooms/:id : 필드 수정 → 변경 반영 확인
   - DELETE /showrooms/:id : soft delete 후 GET 요청 시 404 확인
   
<img width="1491" height="936" alt="스크린샷 2025-08-28 215436" src="https://github.com/user-attachments/assets/b283ba1c-cace-40e4-a17c-caed8fddbca6" />

## 🔗 관련 이슈
- Closes #69 

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [x] 테스트 코드 추가/수정
- [x] 불필요한 코드/로그 제거