### PR TITLE
[FEAT] 프로젝트 관리자 페이지 연동 작업 초안 진행

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage/
 *.log
 logs/
 src/generated/prisma/
+firebase-config.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
         "firebase-admin": "^13.4.0",
-        "multer": "^2.0.2"
+        "multer": "^2.0.2",
+        "zod": "^4.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.31.0",
@@ -5818,6 +5819,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
+      "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "docker:down": "docker compose down --volumes",
     "docker:clean": "docker compose down --volumes --rmi all --remove-orphans"
   },
+  "prisma": {
+    "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
+  },
   "lint-staged": {
     "*.{js,ts}": [
       "eslint --fix",
@@ -54,6 +57,7 @@
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
     "firebase-admin": "^13.4.0",
-    "multer": "^2.0.2"
+    "multer": "^2.0.2",
+    "zod": "^4.1.5"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,40 +43,70 @@ model AdminLog {
 }
 
 model Project {
-  id            Int         @id @default(autoincrement())
-  title         String
-  areaSize      Int
-  type          ProjectType
-  description   String?
-  durationWeeks Int?
-  reviews       String?
-  imageUrl      String?
-  createdAt     DateTime    @default(now())
-  updatedAt     DateTime    @updatedAt
-  isDeleted     Boolean     @default(false)
+  id          Int       @id @default(autoincrement())
+  title       String
+  size        Int
+  category    Category  @default(RESIDENCE)
+  description String?
+  duration    Int?
+  lineup      Lineup    @default(FULL)
+  review      String?
+  imageUrl    String?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  deletedAt   DateTime?
+  isDeleted   Boolean   @default(false)
 
-  projectImages ProjectImage[]
+  images ProjectImage[]
+  tags   ProjectTag[]
 
   @@index([isDeleted])
-  @@index([type, areaSize])
+  @@index([category, size])
   @@map("projects")
 }
 
-enum ProjectType {
-  RESIDENCE // 주거공간
-  MERCANTILE // 상업공간
-  ARCHITECTURE // 건축물
+enum Category {
+  RESIDENCE
+  MERCANTILE
+  ARCHITECTURE
+}
+
+enum Lineup {
+  FULL
+  PARTIAL
+}
+
+model Tag {
+  id        Int      @id @default(autoincrement())
+  name      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  isDeleted Boolean  @default(false)
+
+  projects ProjectTag[]
+  images   ProjectImage[]
+}
+
+model ProjectTag {
+  projectId Int
+  tagId     Int
+
+  project Project @relation(fields: [projectId], references: [id])
+  tag     Tag     @relation(fields: [tagId], references: [id])
+
+  @@id([projectId, tagId])
+  @@map("project_tags")
 }
 
 model ProjectImage {
   id        Int @id @default(autoincrement())
   projectId Int
   imageId   Int
+  tagId     Int
 
   project Project @relation(fields: [projectId], references: [id])
   image   Image   @relation(fields: [imageId], references: [id], onDelete: Cascade)
-
-  imageKeywords ProjectImageKeyword[]
+  tag     Tag     @relation(fields: [tagId], references: [id])
 
   @@unique([imageId, projectId])
   @@map("project_images")
@@ -95,29 +125,6 @@ model Image {
   furnitureImages FurnitureImage[]
 
   @@map("image_urls")
-}
-
-model ProjectImageKeyword {
-  projectId Int
-  imageId   Int
-  keywordId Int
-
-  projectImage ProjectImage @relation(fields: [imageId, projectId], references: [imageId, projectId], onDelete: Cascade)
-  keyword      Keyword      @relation(fields: [keywordId], references: [id])
-
-  @@id([projectId, imageId, keywordId])
-  @@map("project_image_keywords")
-}
-
-model Keyword {
-  id        Int      @id @default(autoincrement())
-  name      String   @unique
-  createdAt DateTime @default(now())
-
-  imageKeywords ProjectImageKeyword[]
-
-  @@index([name])
-  @@map("keywords")
 }
 
 model Company {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,51 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  // 태그 목록
+  const tags = [
+    // RESIDENCE, 100번대
+    { id: 101, name: '현관' },
+    { id: 102, name: '거실' },
+    { id: 103, name: '욕실' },
+    { id: 104, name: '주방' },
+    { id: 105, name: '방' },
+    { id: 106, name: '베란다' },
+
+    // MERCANTILE, 200번대
+    { id: 201, name: '사무공간' },
+    { id: 202, name: '휴게공간' },
+    { id: 203, name: '주방' },
+    { id: 204, name: '홀' },
+    { id: 205, name: '가구' },
+
+    // ARCHITECTURE, 300번대
+    { id: 301, name: '외부' },
+    { id: 302, name: '내부' },
+    { id: 303, name: '조감도' },
+  ];
+
+  // 태그 삽입 (upsert 사용 → 중복 실행해도 안전)
+  for (const tag of tags) {
+    await prisma.tag.upsert({
+      where: { id: tag.id },
+      update: { name: tag.name },
+      create: {
+        id: tag.id,
+        name: tag.name,
+      },
+    });
+  }
+
+  console.log('Tag seeding completed');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,9 +7,9 @@ import { globalErrorHandler } from './handlers/global-error-handler';
 import { notFoundHandler } from './handlers/not-found-handler';
 import rootRouter from './routers/root-router';
 import projectRouter from './routers/projects-router';
-//import imageUploadRouter from './routers/image-upload-router';
-import projectImageRouter from './routers/project-image-router';
-import keywordRouter from './routers/keyword-router';
+import imageUploadRouter from './routers/image-upload-router';
+//import projectImageRouter from './routers/project-image-router';
+//import keywordRouter from './routers/keyword-router';
 import authRouter from './routers/auth-router';
 import consultingRouter from './routers/consultings-router';
 import noticeRouter from './routers/notice-router';
@@ -18,17 +18,23 @@ import showroomRouter from './routers/showroom.router';
 const app = express();
 
 // PRE MIDDLEWARE
-app.use(cors());
+app.use(
+  cors({
+    origin: '*',
+    methods: ['GET', 'POST', 'PATCH', 'DELETE'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+  })
+);
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 
 // ROUTERS
 app.use(rootRouter);
-app.use(projectRouter);
-//app.use(imageUploadRouter);
-app.use(projectImageRouter);
-app.use(keywordRouter);
+app.use('/projects', projectRouter);
+app.use(imageUploadRouter);
+//app.use(projectImageRouter);
+//app.use(keywordRouter);
 app.use(authRouter);
 app.use(consultingRouter);
 app.use(noticeRouter);

--- a/src/controllers/image-upload-controller.ts
+++ b/src/controllers/image-upload-controller.ts
@@ -12,6 +12,7 @@ export const uploadImages: RequestHandler = async (req, res, next) => {
     if (!files) {
       throw new BadRequestError('파일이 존재하지 않습니다.');
     }
+
     const uploadedUrls = await Promise.all(
       files.map(async (file) => {
         const { originalname, buffer, mimetype } = file;

--- a/src/controllers/project-controller.ts
+++ b/src/controllers/project-controller.ts
@@ -1,9 +1,39 @@
 import { RequestHandler } from 'express';
 import { successResponse } from '../utils/response-util';
-import { ProjectService } from '../services/project-service';
-import { toNumber, toString, parseProjectType } from '../utils/query-parser';
-import { BadRequestError, NotFoundError } from '../types/error-type';
+import {
+  createProject,
+  deleteProject,
+  getProjectDetail,
+  getProjectList,
+  updateProject,
+} from '../services/project-service';
 
+export const handleGetProjectList: RequestHandler = async (req, res) => {
+  const projects = await getProjectList(req);
+  return res.json(successResponse(projects));
+};
+
+export const handleCreateProject: RequestHandler = async (req, res) => {
+  const project = await createProject(req);
+  return res.status(201).json(successResponse(project));
+};
+
+export const handleGetProjectDetail: RequestHandler = async (req, res) => {
+  const project = await getProjectDetail(req);
+  return res.json(successResponse(project));
+};
+
+export const handleUpdateProject: RequestHandler = async (req, res) => {
+  const project = await updateProject(req);
+  return res.json(successResponse(project));
+};
+
+export const handleDeleteProject: RequestHandler = async (req, res) => {
+  const project = await deleteProject(req);
+  return res.json(successResponse(project));
+};
+
+/* 
 const projectService = new ProjectService();
 
 export const createProject: RequestHandler = async (req, res, next) => {
@@ -83,3 +113,4 @@ export const deleteProject: RequestHandler = async (req, res, next) => {
     return next(error);
   }
 };
+ */

--- a/src/routers/projects-router.ts
+++ b/src/routers/projects-router.ts
@@ -1,18 +1,18 @@
 import express from 'express';
 import {
-  createProject,
-  getProjects,
-  getProjectById,
-  updateProject,
-  deleteProject,
+  handleCreateProject,
+  handleDeleteProject,
+  handleGetProjectDetail,
+  handleGetProjectList,
+  handleUpdateProject,
 } from '../controllers/project-controller';
 
 const projects = express.Router();
 
-projects.get('/projects', getProjects);
-projects.get('/projects/:id', getProjectById);
-projects.post('/projects', createProject);
-projects.patch('/projects/:id', updateProject);
-projects.delete('/projects/:id', deleteProject);
+projects.post('/', handleCreateProject);
+projects.get('/', handleGetProjectList);
+projects.get('/:id', handleGetProjectDetail);
+projects.patch('/:id', handleUpdateProject);
+projects.delete('/:id', handleDeleteProject);
 
 export default projects;

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -1,8 +1,41 @@
-import { Prisma, ProjectType } from '@prisma/client';
-import { ProjectRepository } from '../repositories/project-repository';
-import { CreateProjectDto, GetProjectsQuery } from '../types/project-type';
-import { NotFoundError } from '../types/error-type';
+import { Request } from 'express';
+import {
+  createProjectWithTransaction,
+  deleteProjectWithId,
+  getProjectDetailWithId,
+  getProjectListWithFilter,
+  updateProjectWithTransaction,
+} from '../repositories/project-repository';
 
+export const getProjectList = async (req: Request) => {
+  const { query } = req;
+  return await getProjectListWithFilter(query);
+};
+
+export const createProject = async (req: Request) => {
+  const { body } = req;
+  return await createProjectWithTransaction(body);
+};
+
+export const getProjectDetail = async (req: Request) => {
+  const { params } = req;
+  const { id } = params;
+  return await getProjectDetailWithId(Number(id));
+};
+
+export const updateProject = async (req: Request) => {
+  const { params, body } = req;
+  const { id } = params;
+  return await updateProjectWithTransaction(Number(id), body);
+};
+
+export const deleteProject = async (req: Request) => {
+  const { params } = req;
+  const { id } = params;
+  return await deleteProjectWithId(Number(id));
+};
+
+/* 
 type ProjectImageDto = {
   id: number; // imageId
   url: string;
@@ -89,3 +122,4 @@ export class ProjectService {
     return await this.projectRepository.softDeleteProject(id);
   }
 }
+ */

--- a/src/types/project-type.ts
+++ b/src/types/project-type.ts
@@ -1,5 +1,50 @@
-import { ProjectType } from '@prisma/client';
+export enum Category {
+  RESIDENCE = 'RESIDENCE',
+  MERCANTILE = 'MERCANTILE',
+  ARCHITECTURE = 'ARCHITECTURE',
+}
 
+export enum ProjectLineup {
+  FULL = 'FULL',
+  PARTIAL = 'PARTIAL',
+}
+
+export interface CreateProjectRequest {
+  title: string;
+  size: number;
+  category?: Category;
+  description?: string;
+  duration?: number;
+  lineup?: ProjectLineup;
+  review?: string;
+  images: {
+    url: string;
+    tagId: number;
+  }[];
+}
+
+export interface UpdateProjectRequest {
+  title: string;
+  size: number;
+  category?: Category;
+  description?: string;
+  duration?: number;
+  lineup?: ProjectLineup;
+  review?: string;
+  images: {
+    url: string;
+    tagId: number;
+  }[];
+}
+
+export type GetProjectListQuery = {
+  category?: Category;
+  page?: number;
+  pageSize?: number;
+  keyword?: string;
+};
+
+/* 
 export interface CreateProjectDto {
   title: string;
   areaSize: number;
@@ -53,3 +98,4 @@ export type Paged<T> = {
   total: number;
   rows: T[];
 };
+ */

--- a/src/utils/from-util.ts
+++ b/src/utils/from-util.ts
@@ -1,5 +1,19 @@
 import { Request } from 'express';
+import { Category } from '../types/project-type';
 
 export const getIp = (req: Request): string => req.ip || 'unknown';
 export const getUrl = (req: Request): string => req.url || 'unknown';
 export const getMethod = (req: Request): string => req.method || 'unknown';
+
+export const getDefaultTagsByType = (type: Category): number[] => {
+  switch (type) {
+    case Category.RESIDENCE:
+      return [101, 102, 103, 104, 105, 106];
+    case Category.MERCANTILE:
+      return [201, 202, 203, 204, 205];
+    case Category.ARCHITECTURE:
+      return [301, 302, 303];
+    default:
+      return [];
+  }
+};

--- a/src/utils/to-util.ts
+++ b/src/utils/to-util.ts
@@ -1,1 +1,19 @@
+import { Category } from '@prisma/client';
+
 export const bytesToMB = (bytes: number): string => (bytes / 1024 / 1024).toFixed(2) + 'MB';
+
+export const toCategory = (category: string | undefined): Category => {
+  switch (category) {
+    case 'RESIDENCE':
+    case '100':
+      return Category.RESIDENCE;
+    case 'MERCANTILE':
+    case '200':
+      return Category.MERCANTILE;
+    case 'ARCHITECTURE':
+    case '300':
+      return Category.ARCHITECTURE;
+    default:
+      return Category.RESIDENCE;
+  }
+};


### PR DESCRIPTION

## 🎯 목적
- 관리자 페이지로 프로젝트 생성/수동/삭제(소프트) 연동

## 📌 변경 사항
- 관리자 페이지의 프로젝트 생성 방법에 따라서 API 가 새로이 작성되었습니다.

## 💡 기대 효과
- 관리자 페이지로 프로젝트 생성/수정/삭제 가능

## 🧪 테스트 방법
<img width="1909" height="862" alt="스크린샷 2025-09-01 오후 3 54 02" src="https://github.com/user-attachments/assets/c9441444-1ef6-42ba-818f-4829f4839ef1" />


## 🔗 관련 이슈
- Closes #71

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 추가/수정
- [ ] 불필요한 코드/로그 제거