### PR TITLE
fix: 공지사항 조회 권한을 User에서 None으로 변경

### DIFF
--- a/src/routers/notice-router.ts
+++ b/src/routers/notice-router.ts
@@ -13,8 +13,8 @@ import {
 const noticeRouter = express.Router();
 
 noticeRouter.post('/notices', allow([UserRole.User]), createNotice);
-noticeRouter.get('/notices', allow([UserRole.User]), getNotices);
-noticeRouter.get('/notices/:id', allow([UserRole.User]), getNoticeDetail);
+noticeRouter.get('/notices', allow([UserRole.None]), getNotices);
+noticeRouter.get('/notices/:id', allow([UserRole.None]), getNoticeDetail);
 noticeRouter.patch('/notices/:id', allow([UserRole.User]), updateNotice);
 noticeRouter.delete('/notices/:id', allow([UserRole.User]), deleteNotice);
 


### PR DESCRIPTION
## 🎯 목적
- 공지사항 조회는 사용자 페이지에서도 확인되기 때문에 권한 확인이 불필요함

## 📌 변경 사항
- src/routers/notice-router.ts get 메소드 시 권한 user -> none로 수정

## 💡 기대 효과
- 토큰 검증 및 권한 확인 없이 공지사항 조회 가능

## 🧪 테스트 방법
- 프론트 연동 후 공지 조회

## 🔗 관련 이슈
- Closes #82

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 추가/수정
- [ ] 불필요한 코드/로그 제거