### PR TITLE
feat: Furniture API 기능 구현

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,7 @@ import consultingRouter from './routers/consultings-router';
 import noticeRouter from './routers/notice-router';
 import showroomRouter from './routers/showroom.router';
 import companyRouter from './routers/company.router';
+import furnitureRouter from './routers/furniture.router';
 
 const app = express();
 
@@ -41,6 +42,7 @@ app.use('/consultings', consultingRouter);
 app.use(noticeRouter);
 app.use(showroomRouter);
 app.use('/company', companyRouter);
+app.use(furnitureRouter);
 
 // POST MIDDLEWARE
 app.use(notFoundHandler); // 생성되지 않은 엔드포인트로 접근 시 404 처리

--- a/src/controllers/furniture.controller.ts
+++ b/src/controllers/furniture.controller.ts
@@ -1,0 +1,58 @@
+import type { RequestHandler } from 'express';
+import { FurnitureService } from '../services/furniture.service';
+import { successResponse } from '../utils/response-util';
+import {
+  listFurnitureQuerySchema,
+  createFurnitureSchema,
+  updateFurnitureSchema,
+} from '../types/furniture.type';
+
+const furnitureService = new FurnitureService();
+
+export const createFurniture: RequestHandler = async (req, res, next) => {
+  try {
+    const body = createFurnitureSchema.parse(req.body);
+    const created = await furnitureService.createFurniture(body);
+    return res.status(201).json(successResponse(created));
+  } catch (e) {
+    return next(e);
+  }
+};
+
+export const getFurnitures: RequestHandler = async (req, res, next) => {
+  try {
+    const q = listFurnitureQuerySchema.parse(req.query);
+    const data = await furnitureService.getFurnitures(q);
+    return res.status(200).json(successResponse(data));
+  } catch (e) {
+    return next(e);
+  }
+};
+
+export const getFurnitureById: RequestHandler = async (req, res, next) => {
+  try {
+    const data = await furnitureService.getFurnitureById(Number(req.params.id));
+    return res.status(200).json(successResponse(data));
+  } catch (e) {
+    return next(e);
+  }
+};
+
+export const updateFurniture: RequestHandler = async (req, res, next) => {
+  try {
+    const body = updateFurnitureSchema.parse(req.body);
+    const data = await furnitureService.updateFurniture(Number(req.params.id), body);
+    return res.status(200).json(successResponse(data));
+  } catch (e) {
+    return next(e);
+  }
+};
+
+export const deleteFurniture: RequestHandler = async (req, res, next) => {
+  try {
+    const data = await furnitureService.deleteFurniture(Number(req.params.id));
+    return res.status(200).json(successResponse(data));
+  } catch (e) {
+    return next(e);
+  }
+};

--- a/src/repositories/furniture.repository.ts
+++ b/src/repositories/furniture.repository.ts
@@ -1,0 +1,70 @@
+import type { Prisma } from '@prisma/client';
+import prisma from '../config/db';
+import type { CreateFurnitureInput, UpdateFurnitureInput } from '../types/furniture.type';
+
+export class FurnitureRepository {
+  async createFurniture(data: CreateFurnitureInput) {
+    const { name, address, phoneNumber, description, introText, imageUrl } = data;
+
+    return prisma.furniture.create({
+      data: { name, address, phoneNumber, description, introText, imageUrl },
+    });
+  }
+
+  async findFurnitureById(id: number) {
+    return prisma.furniture.findFirst({
+      where: { id, isDeleted: false },
+      include: {
+        furnitureImages: { include: { image: true }, orderBy: { imageId: 'asc' } },
+      },
+    });
+  }
+
+  /** 삭제/미삭제 전체에서 이름으로 찾기 (name @unique) */
+  async findAnyByName(name: string) {
+    return prisma.furniture.findUnique({ where: { name } });
+  }
+
+  /** 일반적으로 생성 전에 사용할, '미삭제 항목' 기준 이름 중복 체크 */
+  async findFurnitureByName(name: string) {
+    return prisma.furniture.findFirst({
+      where: { name, isDeleted: false },
+      select: { id: true },
+    });
+  }
+
+  async updateFurniture(id: number, data: UpdateFurnitureInput) {
+    return prisma.furniture.update({ where: { id }, data });
+  }
+
+  async softDeleteFurniture(id: number) {
+    return prisma.furniture.update({ where: { id }, data: { isDeleted: true } });
+  }
+
+  async listFurnitures(params: {
+    where: Prisma.FurnitureWhereInput;
+    skip: number;
+    take: number;
+    orderBy: Prisma.FurnitureOrderByWithRelationInput;
+  }) {
+    const { where, skip, take, orderBy } = params;
+
+    const [items, total] = await Promise.all([
+      prisma.furniture.findMany({
+        where,
+        skip,
+        take,
+        orderBy,
+        select: {
+          id: true,
+          name: true,
+          address: true,
+          imageUrl: true,
+        },
+      }),
+      prisma.furniture.count({ where }),
+    ]);
+
+    return { items, total };
+  }
+}

--- a/src/routers/furniture.router.ts
+++ b/src/routers/furniture.router.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import {
+  createFurniture,
+  getFurnitures,
+  getFurnitureById,
+  updateFurniture,
+  deleteFurniture,
+} from '../controllers/furniture.controller';
+import { allow } from '../middlewares/allow-middleware';
+import { UserRole } from '../enums/user-role-enum';
+
+const router = Router();
+
+router.post('/furnitures', allow([UserRole.User]), createFurniture);
+router.get('/furnitures', allow([UserRole.User]), getFurnitures);
+router.get('/furnitures/:id', allow([UserRole.User]), getFurnitureById);
+router.patch('/furnitures/:id', allow([UserRole.User]), updateFurniture);
+router.delete('/furnitures/:id', allow([UserRole.User]), deleteFurniture);
+
+export default router;

--- a/src/routers/showroom.router.ts
+++ b/src/routers/showroom.router.ts
@@ -6,13 +6,15 @@ import {
   updateShowroom,
   deleteShowroom,
 } from '../controllers/showroom.controller';
+import { allow } from '../middlewares/allow-middleware';
+import { UserRole } from '../enums/user-role-enum';
 
 const router = Router();
 
-router.post('/showrooms', createShowroom);
-router.get('/showrooms', getShowrooms);
-router.get('/showrooms/:id', getShowroomById);
-router.patch('/showrooms/:id', updateShowroom);
-router.delete('/showrooms/:id', deleteShowroom);
+router.post('/showrooms', allow([UserRole.User]), createShowroom);
+router.get('/showrooms', allow([UserRole.User]), getShowrooms);
+router.get('/showrooms/:id', allow([UserRole.User]), getShowroomById);
+router.patch('/showrooms/:id', allow([UserRole.User]), updateShowroom);
+router.delete('/showrooms/:id', allow([UserRole.User]), deleteShowroom);
 
 export default router;

--- a/src/services/furniture.service.ts
+++ b/src/services/furniture.service.ts
@@ -1,0 +1,94 @@
+import { Prisma } from '@prisma/client';
+import { FurnitureRepository } from '../repositories/furniture.repository';
+import { NotFoundError, BadRequestError } from '../types/error-type';
+import { normalizePageParams } from '../utils/pagination';
+import type {
+  CreateFurnitureInput,
+  UpdateFurnitureInput,
+  ListFurnitureQuery,
+  FurnitureDetailDto,
+  FurnitureListItemDto,
+  FurnitureListRecord,
+} from '../types/furniture.type';
+
+const toDetailDto = (
+  f: NonNullable<Awaited<ReturnType<FurnitureRepository['findFurnitureById']>>>
+): FurnitureDetailDto => ({
+  id: f.id,
+  name: f.name,
+  address: f.address,
+  phoneNumber: f.phoneNumber ?? null,
+  description: f.description ?? null,
+  introText: f.introText ?? null,
+  coverImageUrl: f.imageUrl ?? null,
+  images: f.furnitureImages?.map((fi) => ({ imageUrl: fi.image.url })) ?? [],
+  createdAt: f.createdAt,
+  updatedAt: f.updatedAt,
+});
+
+export class FurnitureService {
+  private furnitureRepository = new FurnitureRepository();
+
+  async createFurniture(data: CreateFurnitureInput) {
+    // showroom.service.ts 형식과 동일하게 '이름 중복' 선검사
+    const dup = await this.furnitureRepository.findFurnitureByName(data.name);
+    if (dup) throw new BadRequestError('Furniture name already exists');
+    return await this.furnitureRepository.createFurniture(data);
+  }
+
+  async getFurnitures(query: ListFurnitureQuery) {
+    const { skip, take, page, pageSize } = normalizePageParams({
+      page: query.page,
+      pageSize: query.pageSize,
+      maxPageSize: 100,
+    });
+
+    const where: Prisma.FurnitureWhereInput = { isDeleted: false };
+    if (query.q) {
+      where.OR = [
+        { name: { contains: query.q, mode: 'insensitive' } },
+        { address: { contains: query.q, mode: 'insensitive' } },
+        { description: { contains: query.q, mode: 'insensitive' } },
+      ];
+    }
+
+    let orderBy: Prisma.FurnitureOrderByWithRelationInput = { createdAt: 'desc' };
+    if (query.sort === 'name_asc') orderBy = { name: 'asc' };
+    if (query.sort === 'name_desc') orderBy = { name: 'desc' };
+    if (query.sort === 'recent') orderBy = { createdAt: 'desc' };
+
+    const { items, total } = await this.furnitureRepository.listFurnitures({
+      where,
+      skip,
+      take,
+      orderBy,
+    });
+
+    const shaped: FurnitureListItemDto[] = (items as FurnitureListRecord[]).map((it) => ({
+      id: it.id,
+      name: it.name,
+      address: it.address,
+      coverImageUrl: it.imageUrl ?? null,
+    }));
+
+    return { page, pageSize, total, items: shaped };
+  }
+
+  async getFurnitureById(id: number): Promise<FurnitureDetailDto> {
+    const f = await this.furnitureRepository.findFurnitureById(id);
+    if (!f) throw new NotFoundError('Furniture not found');
+    return toDetailDto(f);
+  }
+
+  async updateFurniture(id: number, data: UpdateFurnitureInput) {
+    const f = await this.furnitureRepository.findFurnitureById(id);
+    if (!f) throw new NotFoundError('Furniture not found');
+    return await this.furnitureRepository.updateFurniture(id, data);
+  }
+
+  async deleteFurniture(id: number) {
+    const f = await this.furnitureRepository.findFurnitureById(id);
+    if (!f) throw new NotFoundError('Furniture not found');
+    return await this.furnitureRepository.softDeleteFurniture(id);
+  }
+}

--- a/src/types/furniture.type.ts
+++ b/src/types/furniture.type.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+export const listFurnitureQuerySchema = z.object({
+  page: z.coerce.number().optional(),
+  pageSize: z.coerce.number().optional(),
+  q: z.string().optional(),
+  sort: z.enum(['recent', 'name_asc', 'name_desc']).optional(),
+});
+
+// 생성 및 수정 공통 스키마
+export const createFurnitureSchema = z.object({
+  name: z.string().min(1).max(255),
+  address: z.string().min(1).max(255),
+  phoneNumber: z.string().max(20).optional().nullable(),
+  description: z.string().optional().nullable(),
+  introText: z.string().optional().nullable(),
+  imageUrl: z.string().url().optional().nullable(),
+});
+
+export const updateFurnitureSchema = createFurnitureSchema.partial();
+
+export type ListFurnitureQuery = z.infer<typeof listFurnitureQuerySchema>;
+export type CreateFurnitureInput = z.infer<typeof createFurnitureSchema>;
+export type UpdateFurnitureInput = z.infer<typeof updateFurnitureSchema>;
+
+// API 응답에 사용하는 타입
+export type FurnitureListItemDto = {
+  id: number;
+  name: string;
+  address: string;
+  coverImageUrl: string | null;
+};
+
+export type FurnitureImageDto = { imageUrl: string };
+
+// 상세조회 API 응답에 사용하는 타입
+export type FurnitureDetailDto = {
+  id: number;
+  name: string;
+  address: string;
+  phoneNumber: string | null;
+  description: string | null;
+  introText: string | null;
+  coverImageUrl: string | null;
+  images: FurnitureImageDto[];
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+// DB에서 직접 사용하는 타입
+export type FurnitureListRecord = {
+  id: number;
+  name: string;
+  address: string;
+  imageUrl: string | null;
+};


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 계약 목록 페이지네이션 구현 -->

## 🎯 목적
- 직영 가구점(Furniture) 정보를 관리하기 위한 CRUD API를 추가했습니다.

## 📌 변경 사항
- FurnitureRepository, FurnitureService, FurnitureController, furniture.router.ts, furniture.type.ts 추가

## 💡 기대 효과
- 가구점 데이터를 일관된 구조로 관리 가능
- 운영팀/프론트엔드에서 CRUD 기능 사용 편의성 향상
- 코드 구조 통일성 및 유지보수성 강화

## 🧪 테스트 방법
- 로컬 서버 실행 (npm run dev)
- Postman으로 POST /furnitures 호출 → 신규 데이터 등록 확인
- GET /furnitures 목록 조회 → 검색/정렬/페이지네이션 정상 동작 확인
- GET /furnitures/:id 상세 조회 → 이미지 포함 데이터 확인
- PATCH /furnitures/:id 수정 → 반영 확인
- DELETE /furnitures/:id 삭제 → 목록에서 제외 확인
<img width="1494" height="915" alt="스크린샷 2025-09-03 161853" src="https://github.com/user-attachments/assets/5c0de1ed-e84e-46a8-9574-4c76e202006f" />


## 🔗 관련 이슈
- Closes #84 

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 추가/수정
- [x] 불필요한 코드/로그 제거