### PR TITLE
refactor: showrooms, furnitures 라우터 접근 권한 변경

### DIFF
--- a/src/routers/furniture.router.ts
+++ b/src/routers/furniture.router.ts
@@ -12,8 +12,8 @@ import { UserRole } from '../enums/user-role-enum';
 const router = Router();
 
 router.post('/furnitures', allow([UserRole.User]), createFurniture);
-router.get('/furnitures', allow([UserRole.User]), getFurnitures);
-router.get('/furnitures/:id', allow([UserRole.User]), getFurnitureById);
+router.get('/furnitures', allow([UserRole.None]), getFurnitures);
+router.get('/furnitures/:id', allow([UserRole.None]), getFurnitureById);
 router.patch('/furnitures/:id', allow([UserRole.User]), updateFurniture);
 router.delete('/furnitures/:id', allow([UserRole.User]), deleteFurniture);
 

--- a/src/routers/showroom.router.ts
+++ b/src/routers/showroom.router.ts
@@ -12,8 +12,8 @@ import { UserRole } from '../enums/user-role-enum';
 const router = Router();
 
 router.post('/showrooms', allow([UserRole.User]), createShowroom);
-router.get('/showrooms', allow([UserRole.User]), getShowrooms);
-router.get('/showrooms/:id', allow([UserRole.User]), getShowroomById);
+router.get('/showrooms', allow([UserRole.None]), getShowrooms);
+router.get('/showrooms/:id', allow([UserRole.None]), getShowroomById);
 router.patch('/showrooms/:id', allow([UserRole.User]), updateShowroom);
 router.delete('/showrooms/:id', allow([UserRole.User]), deleteShowroom);
 


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 계약 목록 페이지네이션 구현 -->

## 🎯 목적
- 가구 조회 API의 접근 권한을 완화하여 비회원 사용자도 데이터를 조회할 수 있도록 하기 위함

📌 변경 사항

## 📌 변경 사항
- GET /furnitures, GET /showrooms 접근 권한을 UserRole.User → UserRole.None으로 변경

- GET /furnitures/:id, GET /showrooms/:id 접근 권한을 UserRole.User → UserRole.None으로 변경

## 💡 기대 효과
- 로그인하지 않은 사용자도 가구 정보를 조회할 수 있어 사용자 접근성 및 초기 진입 장벽 감소

## 🧪 테스트 방법
- 로컬 서버 실행
- 로그인 없이 /furnitures 및 /furnitures/:id API 호출
- 정상적으로 200 응답 및 데이터 반환 확인

## 🔗 관련 이슈
- Closes #86 

## ✅ 체크리스트
- [x] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 추가/수정
- [x] 불필요한 코드/로그 제거