### PR TITLE
가구점 관리자 프론트 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "reset": "npx prisma migrate reset -f",
     "migrate": "npx prisma migrate dev",
+    "seed": "npx prisma db seed",
     "build": "rm -rf dist/* && tsc",
     "start": "node dist/app.js",
     "dev": "nodemon --watch src --ext ts --exec ts-node --files src/app.ts",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,7 +81,9 @@ enum Keyword {
   APART
   HOUSE
   COMMERCIAL
+  OFFICE
   NEW
+  REMODELING
 }
 
 model Tag {

--- a/src/repositories/project-repository.ts
+++ b/src/repositories/project-repository.ts
@@ -7,7 +7,7 @@ import {
   UpdateProjectRequest,
 } from '../types/project-type';
 import { getDefaultTagsByType } from '../utils/from-util';
-import { toCategory, toKeyword, toLineup } from '../utils/to-util';
+import { toCategory, toKeyword, toLineup, toSizeRange } from '../utils/to-util';
 
 export const createProjectWithTransaction = async (data: CreateProjectRequest) => {
   return await prisma.$transaction(async (tx) => {
@@ -69,11 +69,12 @@ export const createProjectWithTransaction = async (data: CreateProjectRequest) =
 };
 
 export const getProjectListWithFilter = async (query: GetProjectListQuery) => {
-  const { category = Category.RESIDENCE, page = 1, size = 10, keyword, search, lineup } = query;
+  const { category, page = 1, size = 10, keyword, search, lineup, pyung } = query;
 
   const categoryEnum = toCategory(category);
   const keywordEnum = toKeyword(keyword);
   const lineupEnum = toLineup(lineup);
+  const sizeRange = toSizeRange(pyung);
 
   const where = {
     isDeleted: false,
@@ -88,6 +89,7 @@ export const getProjectListWithFilter = async (query: GetProjectListQuery) => {
         }
       : {}),
     ...(lineupEnum ? { lineup: lineupEnum } : {}),
+    size: sizeRange,
   };
 
   const [totalCount, list] = await Promise.all([
@@ -130,6 +132,7 @@ export const updateProjectWithTransaction = async (id: number, data: UpdateProje
         duration: data.duration,
         lineup: data.lineup ?? 'FULL',
         review: data.review,
+        keywords: data.keywords,
       },
     });
 

--- a/src/types/project-type.ts
+++ b/src/types/project-type.ts
@@ -1,5 +1,7 @@
 import { Keyword } from '@prisma/client';
 
+export type Pyung = '20' | '30' | '40' | '50' | '60' | 'OTHER';
+
 export enum Category {
   RESIDENCE = 'RESIDENCE',
   MERCANTILE = 'MERCANTILE',
@@ -45,6 +47,7 @@ export type GetProjectListQuery = {
   category?: Category;
   page?: number;
   size?: number;
+  pyung?: Pyung;
   keyword?: Keyword;
   search?: string;
   lineup?: Lineup;

--- a/src/utils/to-util.ts
+++ b/src/utils/to-util.ts
@@ -1,4 +1,4 @@
-import { Category, Keyword } from '@prisma/client';
+import { Category, Keyword, Size } from '@prisma/client';
 import { Lineup } from '../types/project-type';
 
 export const bytesToMB = (bytes: number): string => (bytes / 1024 / 1024).toFixed(2) + 'MB';
@@ -40,6 +40,46 @@ export const toLineup = (lineup: string | undefined): Lineup | undefined => {
       return Lineup.FULL;
     case 'PARTIAL':
       return Lineup.PARTIAL;
+    default:
+      return undefined;
+  }
+};
+
+export const toSizeTag = (sizeTag: string | undefined): string | undefined => {
+  switch (sizeTag) {
+    case 'SIZE20':
+      return Size.SIZE20;
+    case 'SIZE30':
+      return Size.SIZE30;
+    case 'SIZE40':
+      return Size.SIZE40;
+    case 'SIZE50':
+      return Size.SIZE50;
+    case 'SIZE60':
+      return Size.SIZE60;
+    case 'OTHER':
+      return Size.OTHER;
+    default:
+      return undefined;
+  }
+};
+
+export const toSizeRange = (
+  sizeTag: string | undefined
+): { gte?: number; lt?: number } | undefined => {
+  switch (sizeTag) {
+    case '20':
+      return { gte: 20, lt: 30 };
+    case '30':
+      return { gte: 30, lt: 40 };
+    case '40':
+      return { gte: 40, lt: 50 };
+    case '50':
+      return { gte: 50, lt: 60 };
+    case '60':
+      return { gte: 60, lt: 70 };
+    case 'OTHER':
+      return { lt: 20, gte: 70 };
     default:
       return undefined;
   }

--- a/src/utils/token-util.ts
+++ b/src/utils/token-util.ts
@@ -7,7 +7,7 @@ import { CookieType } from '../enums/cookie-type-enum';
 
 // ACCESS_TOKEN 생성
 export const generateAccessToken = (payload: Payload): string => {
-  const { _iat, _exp, ...other } = payload;
+  const { iat, exp, ...other } = payload;
   const expiresIn = `${ENV.accessExpiryValue}${ENV.accessExpiryUnit}`;
 
   return jwt.sign(other, ENV.accessSecretKey, { expiresIn } as jwt.SignOptions);
@@ -15,7 +15,7 @@ export const generateAccessToken = (payload: Payload): string => {
 
 // REFRESH_TOKEN 생성
 export const generateRefreshToken = (payload: Payload): string => {
-  const { _iat, _exp, ...other } = payload;
+  const { iat, exp, ...other } = payload;
   const expiresIn = `${ENV.refreshExpiryValue}${ENV.refreshExpiryUnit}`;
 
   return jwt.sign(other, ENV.refreshSecretKey, { expiresIn } as jwt.SignOptions);


### PR DESCRIPTION
가구점은 API 에 맞춰서 진행했습니다.

## 프로젝트 목록 쿼리 수정
size 가 이미 사용 중이라 pyung 으로 수정했습니다.

### 타입
```typescript
export type Pyung = '20' | '30' | '40' | '50' | '60' | 'OTHER';
```

### 쿼리
```typescript
const { category, page = 1, size = 10, keyword, search, lineup, pyung } = query;
```
 쿼리에 '20' 이렇게 보내면,
 
 ```typescript
 
export const toSizeRange = (
  sizeTag: string | undefined
): { gte?: number; lt?: number } | undefined => {
  switch (sizeTag) {
    case '20':
      return { gte: 20, lt: 30 };
    case '30':
      return { gte: 30, lt: 40 };
    case '40':
      return { gte: 40, lt: 50 };
    case '50':
      return { gte: 50, lt: 60 };
    case '60':
      return { gte: 60, lt: 70 };
    case 'OTHER':
      return { lt: 20, gte: 70 };
    default:
      return undefined;
  }
};
 ```
내부적으로 쿼리를 처리해서 그 조건에 부합하는 프로젝트를 반환합니다.