### PR TITLE
refactor: pyung 배열을 처리하도록 수정

### DIFF
--- a/src/repositories/project-repository.ts
+++ b/src/repositories/project-repository.ts
@@ -7,7 +7,7 @@ import {
   UpdateProjectRequest,
 } from '../types/project-type';
 import { getDefaultTagsByType } from '../utils/from-util';
-import { toCategory, toKeyword, toLineup, toSizeRange } from '../utils/to-util';
+import { toCategory, toKeyword, toLineup, toSizeRanges } from '../utils/to-util';
 
 export const createProjectWithTransaction = async (data: CreateProjectRequest) => {
   return await prisma.$transaction(async (tx) => {
@@ -74,7 +74,7 @@ export const getProjectListWithFilter = async (query: GetProjectListQuery) => {
   const categoryEnum = toCategory(category);
   const keywordEnum = toKeyword(keyword);
   const lineupEnum = toLineup(lineup);
-  const sizeRange = toSizeRange(pyung);
+  const sizeCondition = toSizeRanges(pyung);
 
   const where = {
     isDeleted: false,
@@ -82,14 +82,14 @@ export const getProjectListWithFilter = async (query: GetProjectListQuery) => {
     category: categoryEnum,
     ...(search
       ? {
-          OR: [
-            { title: { contains: search, mode: 'insensitive' as const } },
-            { description: { contains: search, mode: 'insensitive' as const } },
-          ],
-        }
+        OR: [
+          { title: { contains: search, mode: 'insensitive' as const } },
+          { description: { contains: search, mode: 'insensitive' as const } },
+        ],
+      }
       : {}),
     ...(lineupEnum ? { lineup: lineupEnum } : {}),
-    size: sizeRange,
+    ...(sizeCondition ? sizeCondition : {}),
   };
 
   const [totalCount, list] = await Promise.all([

--- a/src/types/project-type.ts
+++ b/src/types/project-type.ts
@@ -47,7 +47,7 @@ export type GetProjectListQuery = {
   category?: Category;
   page?: number;
   size?: number;
-  pyung?: Pyung;
+  pyung?: Pyung[];
   keyword?: Keyword;
   search?: string;
   lineup?: Lineup;

--- a/src/utils/to-util.ts
+++ b/src/utils/to-util.ts
@@ -1,5 +1,5 @@
 import { Category, Keyword } from '@prisma/client';
-import { Lineup } from '../types/project-type';
+import { Lineup, Pyung } from '../types/project-type';
 
 export const bytesToMB = (bytes: number): string => (bytes / 1024 / 1024).toFixed(2) + 'MB';
 
@@ -45,23 +45,38 @@ export const toLineup = (lineup: string | undefined): Lineup | undefined => {
   }
 };
 
-export const toSizeRange = (
-  sizeTag: string | undefined
-): { gte?: number; lt?: number } | undefined => {
-  switch (sizeTag) {
-    case '20':
-      return { gte: 20, lt: 30 };
-    case '30':
-      return { gte: 30, lt: 40 };
-    case '40':
-      return { gte: 40, lt: 50 };
-    case '50':
-      return { gte: 50, lt: 60 };
-    case '60':
-      return { gte: 60, lt: 70 };
-    case 'OTHER':
-      return { lt: 20, gte: 70 };
-    default:
-      return undefined;
+export const toSizeRanges = (
+  pyungArray: Pyung[] | undefined
+): { OR: { size: { gte?: number; lt?: number } }[] } | undefined => {
+  if (!pyungArray || pyungArray.length === 0) {
+    return undefined;
   }
+
+  const ranges: { size: { gte?: number; lt?: number } }[] = [];
+
+  pyungArray.forEach((pyung) => {
+    switch (pyung) {
+      case '20':
+        ranges.push({ size: { gte: 20, lt: 30 } });
+        break;
+      case '30':
+        ranges.push({ size: { gte: 30, lt: 40 } });
+        break;
+      case '40':
+        ranges.push({ size: { gte: 40, lt: 50 } });
+        break;
+      case '50':
+        ranges.push({ size: { gte: 50, lt: 60 } });
+        break;
+      case '60':
+        ranges.push({ size: { gte: 60, lt: 70 } });
+        break;
+      case 'OTHER':
+        ranges.push({ size: { lt: 20 } });
+        ranges.push({ size: { gte: 70 } });
+        break;
+    }
+  });
+
+  return ranges.length > 0 ? { OR: ranges } : undefined;
 };


### PR DESCRIPTION
## 🎯 목적
- 프론트 요청 형식과 DB 데이터 조회 조건 형식 통일 

## 📌 변경 사항
- pyung을 배열로 받고 조회 시 다중 조건으로 수정

## 💡 기대 효과
- 평형에 대한 다양한 정보 조회 가능

## 🧪 테스트 방법
- 로컬 FE / BE 서버 실행
- (FE) 시공사례 메뉴 이동 및 평형 필터 단일 / 다중 적용
- (FE) 정상 데이터 출력 확인
 
## 🔗 관련 이슈
- Closes #92 

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 추가/수정
- [ ] 불필요한 코드/로그 제거