### PR TITLE
feat: nginx api 서버 최대 업로드 용량 변경

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,6 +20,7 @@ http {
     server {
         listen 80;
         server_name api.localhost.com;
+        client_max_body_size 50M;
 
         location / {
             proxy_pass http://api:3001;


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 계약 목록 페이지네이션 구현 -->

## 🎯 목적
- 한 번의 Requset 에 필요한 업로드 용량의 재 설정

## 📌 변경 사항
- nginx.conf 의 api서버 request 용량 제한을 1mb 에서 50mb 로 변경 

## 🔗 관련 이슈
- Closes #98

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 추가/수정
- [ ] 불필요한 코드/로그 제거