### PR TITLE
fix: toSizeRanges 함수의 반환 타입 및 논리 수정

### DIFF
--- a/api/src/utils/to-util.ts
+++ b/api/src/utils/to-util.ts
@@ -50,18 +50,18 @@ export const toLineup = (lineup: string | undefined): Lineup | undefined => {
 };
 
 export const toSizeRanges = (
-  pyungArray: Pyung[] | undefined
-): { OR: { size: { gte?: number; lt?: number } }[] } | undefined => {
-  if (!pyungArray || pyungArray.length === 0) {
-    return undefined;
-  }
-  // pyungArray가 배열이 아니면 배열로 변환
+  pyungArray: Pyung[] | Pyung | undefined
+): { AND: { size: { gte?: number; lt?: number } }[] } | undefined => {
+  if (!pyungArray) return undefined;
   const arr = Array.isArray(pyungArray) ? pyungArray : [pyungArray];
+  if (arr.length === 0) return undefined;
 
   const ranges: { size: { gte?: number; lt?: number } }[] = [];
 
   arr.forEach((pyung) => {
-    switch (pyung) {
+    const value = typeof pyung === 'string' ? pyung.toUpperCase() : pyung;
+
+    switch (value) {
       case '20':
         ranges.push({ size: { gte: 20, lt: 30 } });
         break;
@@ -84,5 +84,5 @@ export const toSizeRanges = (
     }
   });
 
-  return ranges.length > 0 ? { OR: ranges } : undefined;
+  return ranges.length > 0 ? { AND: ranges } : undefined;
 };


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 계약 목록 페이지네이션 구현 -->

## 🎯 목적
-toSizeRanges 함수의 반환 타입 및 논리 수정

## 📌 변경 사항
- toSizeRanges 함수의 반환 타입 및 논리 수정

## 🔗 관련 이슈
- Closes #123 

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 추가/수정
- [ ] 불필요한 코드/로그 제거